### PR TITLE
Update README to point to podman-login action

### DIFF
--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -1,9 +1,13 @@
 name: OpenShift Pet Clinic Workflow
-on: [ push, workflow_dispatch ]
+on:
+  push:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'  # every day at midnight
 
 env:
   IMAGE_PATH: quay.io/diagrawa/petclinic:latest
-  TEST_NAMESPACE: diagrawa-code
+  TEST_NAMESPACE: github-actions-bot-dev
   APP_NAME: petclinic
   APP_PORT: 8080
 
@@ -30,7 +34,7 @@ jobs:
       - name: OpenShift login
         uses: redhat-actions/oc-login@v1
         with:
-          openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
+          openshift_server_url: ${{ secrets.OPENSHIFT_URL }}
           openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
           # openshift_username:
           # openshift_password:

--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     paths:
       -'**.md'
+  schedule:
+    - cron: '0 0 * * *'  # every day at midnight
 
 jobs:
   markdown-link-check:

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For a complete example see the [example workflow](.github/workflows/example.yml)
 
 ## Using private images
 
-If your deployment requires private image, use [**podman-login**](https://github.com/redhat-actions/podman-login) action in a step before running this action to authenticate to the container image registry.
+If your deployment requires a private image, run [**podman-login**](https://github.com/redhat-actions/podman-login) in a step before this action so you can pull the image.
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,17 @@ For a complete example see the [example workflow](.github/workflows/example.yml)
 
 ## Using private images
 
-If your deployment requires private image, you have to `docker login` in a step before running this action.
+If your deployment requires private image, use [**podman-login**](https://github.com/redhat-actions/podman-login) action in a step before running this action to authenticate to the container image registry.
 
 For example:
 
 ```yaml
-- name: Log in to Quay.io
-  run: echo "${{ secrets.QUAY_IO_PASSWORD }}" | docker login quay.io -u "${{ secrets.QUAY_IO_USER }}" --password-stdin
+- name: Log in to quay.io
+  uses: redhat-action/podman-login@v1
+  with:
+    registry: quay.io
+    username: quayuser
+    password: {{ secrets.REGISTRY_PASSWORD }}
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
Signed-off-by: divyansh42 <diagrawa@redhat.com>

<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description
- Update README to point to `podman-login` action instead of using scripts to login
- Fix workflow CI by updating creds as per new sandbox
- Add cron to the workflow

<!--
A short and simple description of what this PR aims to accomplish.
-->

### Checklist

- [x] This PR includes a documentation change
- [ ] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [x] This PR's changes are already tested
---
- [x] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change


