### PR TITLE
Modernize CI workflows with latest action versions

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -1,49 +1,60 @@
 name: CI checks
 on:
   push:
+    paths-ignore:
+      - '**.md'
   pull_request:
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:
     name: Run ESLint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - run: npm ci
       - run: npm run lint
-  
+
   check-dist:
     name: Check Distribution
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       BUNDLE_FILE: "dist/index.js"
       BUNDLE_COMMAND: "npm run bundle"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install
         run: npm ci
 
       - name: Verify Latest Bundle
-        uses: redhat-actions/common/bundle-verifier@v1
+        uses: redhat-actions/common/bundle-verifier@v2
         with:
           bundle_file: ${{ env.BUNDLE_FILE }}
           bundle_command: ${{ env.BUNDLE_COMMAND }}
-  
+
   check-inputs-outputs:
     name: Check Input and Output enums
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     env:
       IO_FILE: ./src/generated/inputs-outputs.ts
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Install dependencies
         run: npm ci
-    
+
       - name: Verify Input and Output enums
-        uses: redhat-actions/common/action-io-generator@v1
+        uses: redhat-actions/common/action-io-generator@v2
         with:
           io_file: ${{ env.IO_FILE }}

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
 
+permissions:
+  contents: read
+
 env:
   IMAGE_PATH: quay.io/redhat-github-actions/petclinic:latest
   APP_NAME: petclinic
@@ -28,21 +31,21 @@ jobs:
       matrix:
         image-source: [ "IMAGE_PATH", "IMAGE_STREAM" ]
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout action
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
        # Use the commit short-sha as the suffix of the app_name
       - name: Get commit short-sha
         id: commit-data
-        uses: redhat-actions/common/commit-data@v1
+        uses: redhat-actions/common/commit-data@v2
 
       # Log into the OpenShift cluster using the secrets configured in the repository settings.
       # The GitHub Ubuntu runners have oc pre-installed.
       # If you're not using those runners, be sure to check out https://github.com/redhat-actions/openshift-tools-installer.
       - name: OpenShift login
-        uses: redhat-actions/oc-login@v1
+        uses: redhat-actions/oc-login@v2
         with:
           openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
           openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
@@ -84,7 +87,7 @@ jobs:
       # This step is retried since the time to pull the image and start the pod can vary.
       - name: Test project is running
         id: test-project
-        uses: nick-invision/retry@v2.2.0
+        uses: nick-fields/retry@v4
         with:
           timeout_seconds: 3
           retry_wait_seconds: 10

--- a/.github/workflows/example_private_image.yml
+++ b/.github/workflows/example_private_image.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
 
+permissions:
+  contents: read
+
 env:
   IMAGE_PATH: quay.io/redhat-github-actions/petclinic-private:latest
   APP_NAME: petclinic
@@ -23,14 +26,14 @@ jobs:
       matrix:
         auth-type: [ "docker", "podman" ]
 
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: OpenShift login
-        uses: redhat-actions/oc-login@v1
+        uses: redhat-actions/oc-login@v2
         with:
-          openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }} 
+          openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
           openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
           insecure_skip_tls_verify: true
           namespace: ${{ secrets.OPENSHIFT_NAMESPACE }}
@@ -42,7 +45,7 @@ jobs:
 
       - name: Podman login
         if: ${{ matrix.auth-type == 'podman' }}
-        uses: redhat-actions/podman-login@v1
+        uses: redhat-actions/podman-login@v2
         with:
           registry: quay.io
           username: ${{ env.REGISTRY_USERNAME }}
@@ -69,7 +72,7 @@ jobs:
       # This step is retried since the time to pull the image and start the pod can vary.
       - name: Test project is running
         id: test-project
-        uses: nick-invision/retry@v2.2.0
+        uses: nick-fields/retry@v4
         with:
           timeout_seconds: 3
           retry_wait_seconds: 10
@@ -85,12 +88,12 @@ jobs:
 
   using-registry-creds:
     name: Create secret using registry creds
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: OpenShift login
-        uses: redhat-actions/oc-login@v1
+        uses: redhat-actions/oc-login@v2
         with:
           openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
           openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
@@ -120,7 +123,7 @@ jobs:
       # This step is retried since the time to pull the image and start the pod can vary.
       - name: Test project is running
         id: test-project
-        uses: nick-invision/retry@v2.2.0
+        uses: nick-fields/retry@v4
         with:
           timeout_seconds: 3
           retry_wait_seconds: 10
@@ -136,12 +139,12 @@ jobs:
 
   using-existing-pull-secret:
     name: Use existing pull secret
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: OpenShift login
-        uses: redhat-actions/oc-login@v1
+        uses: redhat-actions/oc-login@v2
         with:
           openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
           openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
@@ -169,7 +172,7 @@ jobs:
       # This step is retried since the time to pull the image and start the pod can vary.
       - name: Test project is running
         id: test-project
-        uses: nick-invision/retry@v2.2.0
+        uses: nick-fields/retry@v4
         with:
           timeout_seconds: 3
           retry_wait_seconds: 10

--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -9,12 +9,19 @@ on:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   markdown-link-check:
     name: Check links in markdown
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-verbose-mode: true

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -7,21 +7,24 @@ on:
   # schedule:
   #   - cron: '0 0 * * *'  # every day at midnight
 
+permissions:
+  contents: read
+
 jobs:
   crda-scan:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Scan project vulnerability with CRDA
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install CRDA
-        uses: redhat-actions/openshift-tools-installer@v1
+        uses: redhat-actions/openshift-tools-installer@v2
         with:
           source: github
           github_pat: ${{ github.token }}


### PR DESCRIPTION
## Summary
- Upgrade actions/checkout v4 -> v7, actions/setup-node v2 -> v7
- Migrate deprecated nick-invision/retry to nick-fields/retry v4
- Upgrade redhat-actions/common v1 -> v2, oc-login v1 -> v2, podman-login v1 -> v2, openshift-tools-installer v1 -> v2
- Update runs-on from ubuntu-22.04 to ubuntu-24.04 across all workflows
- Add `permissions: contents: read` to all workflows (least privilege)
- Add concurrency groups and path-ignore filters where appropriate
- Update node-version 20 -> 24 in security_scan workflow

## Test plan
- [ ] CI checks workflow runs successfully
- [ ] Example workflows are syntactically valid (workflow_dispatch trigger available for manual validation)
- [ ] Verify no action version incompatibilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)