### PR TITLE
Add security hardening: dependabot, CODEOWNERS, and SECURITY.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @redhat-actions/maintainers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "typescript"
+        versions: [">=7.0.0"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, please report security issues by emailing secalert@redhat.com, or by using the GitHub Security Advisory feature at:
+
+https://github.com/redhat-actions/oc-new-app/security/advisories/new
+
+We will acknowledge receipt of your report and work with you to understand and address the issue.
+
+## Supported Versions
+
+Security updates are provided for the latest major version only.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.x     | Yes                |
+| < 1.0   | No                 |


### PR DESCRIPTION
## Summary
- Add dependabot.yml for weekly npm and GitHub Actions dependency updates (TypeScript v7 ignored until ready to migrate)
- Add CODEOWNERS assigning @redhat-actions/maintainers as default reviewers
- Add SECURITY.md with vulnerability reporting instructions

## Repository settings to apply after merge
The following API calls should be run to complete security hardening:

```bash
# Enable secret scanning and push protection
gh api repos/redhat-actions/oc-new-app --method PATCH \
  -f security_and_analysis[secret_scanning][status]=enabled \
  -f security_and_analysis[secret_scanning_push_protection][status]=enabled

# Set default workflow permissions to read-only
gh api repos/redhat-actions/oc-new-app/actions/permissions/workflow --method PUT \
  -f default_workflow_permissions=read \
  -F can_approve_pull_request_reviews=false
```

## Test plan
- [ ] Dependabot starts creating PRs after merge
- [ ] CODEOWNERS triggers review requests on new PRs
- [ ] SECURITY.md is visible on the repo security tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)